### PR TITLE
No need to raise exception for Rollback

### DIFF
--- a/pyservice/organizer.py
+++ b/pyservice/organizer.py
@@ -13,9 +13,20 @@ class Organizer:
     def __init__(self, actions: List[Action]):
         self.actions = actions
 
+    @staticmethod
+    def _call_action(f: Action, ctx: Context) -> Context:
+        ctx = f(ctx)
+
+        if ctx.is_failure:
+            raise Organizer.ContextFailed(f)
+
+        return ctx
+
     def run(self, ctx: Context) -> Context:
         try:
-            return functools.reduce(lambda _ctx, f: f(_ctx), self.actions, ctx)
+            return functools.reduce(
+                lambda _ctx, f: self._call_action(f, _ctx), self.actions, ctx
+            )
         except Organizer.ContextFailed as e:
             # roll back the actions in reverse order
             actions_to_roll_back = self._find_actions_to_roll_back(

--- a/test/test_doubles.py
+++ b/test/test_doubles.py
@@ -52,7 +52,7 @@ def add_three(ctx: Context) -> Context:
 @action()
 def fail_context(ctx: Context) -> Context:
     ctx.fail("Something went wrong...")
-    raise Organizer.ContextFailed(fail_context)
+    return ctx
 
 
 @action()


### PR DESCRIPTION
As I was using pyservice, I was surprised that no action rollback took
place when I had rollback actions defined. I had to look up the docs to
see why it did not fire.

This commit will roll back automatically after the Context is pushed
into a failure state.